### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/autogen/poetry.lock
+++ b/autogen/poetry.lock
@@ -1642,14 +1642,14 @@ files = [
 tests = ["pytest"]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.1.14"
 description = "Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyautogen-0.1.14-py3-none-any.whl", hash = "sha256:4f12b248af5350958a6073952123a802334b3d3dcd700353cdf25a8aacac4298"},
-    {file = "pyautogen-0.1.14.tar.gz", hash = "sha256:1e9334cc7a69e73907154ff7c9c323f13aab7b70bdc8cce836be7ea92a127fff"},
+    {file = "ag2-0.1.14-py3-none-any.whl", hash = "sha256:4f12b248af5350958a6073952123a802334b3d3dcd700353cdf25a8aacac4298"},
+    {file = "ag2-0.1.14.tar.gz", hash = "sha256:1e9334cc7a69e73907154ff7c9c323f13aab7b70bdc8cce836be7ea92a127fff"},
 ]
 
 [package.dependencies]

--- a/autogen/pyproject.toml
+++ b/autogen/pyproject.toml
@@ -7,4 +7,4 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 common-lib = { path = "../common-lib", develop=true }
 python = "^3.11"
-pyautogen = "0.1.14"
+ag2 = "0.1.14"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
